### PR TITLE
Update util.py to fix s_hat assignment

### DIFF
--- a/utils/util.py
+++ b/utils/util.py
@@ -151,9 +151,9 @@ def getRMatrix(yi, yf):
     if (abs(phi) > 0.1):
         phi = phi * (np.pi / 180)
 
-        s_hat = np.array([[0, -ax[2], ax[1]],
-                          [ax[2], 0, -ax[0]],
-                          [-ax[1], ax[0], 0]])
+        s_hat = np.array([[0, -ax[2][0], ax[1][0]],
+                          [ax[2][0], 0, -ax[0][0]],
+                          [-ax[1][0], ax[0][0], 0]])
         R = np.eye(3) + np.sin(phi) * s_hat + (1 - np.cos(phi)) * np.dot(s_hat, s_hat)      # dot???
     else:
         R = np.eye(3)


### PR DESCRIPTION
This PR resolves an indexing error in getRMatrix by fixing improper indexing of ax in the s_hat array. It ensures smooth execution of the Depth2HHA pipeline.

Resolves ValueError caused by attempting to set an array element with a sequence, resulting in an inhomogeneous shape after 2 dimensions.